### PR TITLE
Upgrade to latest katapod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,4 +18,4 @@ ports:
     onOpen: ignore
 vscode:
    extensions:
-    - https://github.com/hemidactylus/katapod/releases/download/1.1.0-beta2/katapod-1.1.0-beta2.vsix
+    - https://github.com/hemidactylus/katapod/releases/download/1.2.0-pre-release/katapod-1.2.0.vsix

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,7 @@ tasks:
       curl https://dlcdn.apache.org/cassandra/4.1.0/apache-cassandra-4.1.0-bin.tar.gz \
         --output apache-cassandra-4.1.0-bin.tar.gz
       tar xf apache-cassandra-4.1.0-bin.tar.gz
-    command: | 
+    command: |
       /workspace/ds201-lab02/apache-cassandra-4.1.0/bin/cassandra
 github:
   prebuilds:
@@ -18,4 +18,4 @@ ports:
     onOpen: ignore
 vscode:
    extensions:
-    - https://github.com/hemidactylus/katapod/releases/download/1.2.0-pre-release/katapod-1.2.0.vsix
+    - https://github.com/DataStax-Academy/katapod/releases/download/stable/katapod-stable.vsix

--- a/step1.md
+++ b/step1.md
@@ -33,12 +33,12 @@ The video metadata is made up of:
 | title       | text      |
 
 ✅ Use `nodetool` to verify that Cassandra is running (you may need to run this multiple times):
-```
+```bash
 nodetool status
 ```
 
 ✅ Start the command line tool `cqlsh`:
-```
+```bash
 cqlsh
 ```
 
@@ -47,7 +47,7 @@ cqlsh
 <details class="katapod-details">
   <summary>Solution</summary>
 
-```
+```cql
 CREATE KEYSPACE killrvideo
 WITH replication = {
   'class':'SimpleStrategy', 
@@ -56,24 +56,22 @@ WITH replication = {
 ```
 
 </details>
-<br>
 
 ✅ Switch to the newly created keyspace with the *Use* command:
 <details class="katapod-details">
   <summary>Solution</summary>
 
-```
+```bash
 use killrvideo;
 ```
 </details>
-<br>
 
 ✅ Create a table called `videos` with columns `video_id` of type `TIMEUUID`, `added_date` of type `TIMESTAMP` and `title` of type `TEXT`. Designate `video_id` as the primary key.
 
 <details class="katapod-details">
   <summary>Solution</summary>
 
-```
+```cql
 CREATE TABLE videos (
   video_id TIMEUUID,
   added_date TIMESTAMP,
@@ -82,7 +80,7 @@ CREATE TABLE videos (
 );
 ```
 </details>
-<br>
+
 <!-- NAVIGATION -->
 <div id="navigation-bottom" class="navigation-bottom">
  <a href='command:katapod.loadPage?[{"step":"intro"}]'

--- a/step1.md
+++ b/step1.md
@@ -13,7 +13,7 @@
    class="btn btn-dark navigation-top-left">⬅️ Back
  </a>
 <span class="step-count"> Step 1 of 2</span>
- <a href='command:katapod.loadPage?[{"step":"step3"}]' 
+ <a href='command:katapod.loadPage?[{"step":"step2"}]' 
     class="btn btn-dark navigation-top-right">Next ➡️
   </a>
 </div>
@@ -26,26 +26,11 @@ Welcome to the KillrVideo company! KillrVideo hired you to build the latest and 
 
 The video metadata is made up of:
 
-<table class="katapod-table">
-  <tr>
-    <th class="katapod-table">Column Name</th>
-    <th class="katapod-table">Date Type </th>
-  </tr>
-  <tr>
-    <td class="katapod-table">video_id</td>
-    <td class="katapod-table">timeuuid</td>
-  <tr>  
-  <tr>
-    <td class="katapod-table">added_date</td>
-    <td class="katapod-table">timestamp</td>
-  <tr>
-    <tr>
-    <td class="katapod-table">title</td>
-    <td class="katapod-table">text</td>
-  <tr>
-</table>
-
-<br>
+| Column Name | Data Type |
+|-------------|-----------|
+| video_id    | timeuuid  |
+| added_date  | timestamp |
+| title       | text      |
 
 ✅ Use `nodetool` to verify that Cassandra is running (you may need to run this multiple times):
 ```

--- a/step1.md
+++ b/step1.md
@@ -33,11 +33,13 @@ The video metadata is made up of:
 | title       | text      |
 
 ✅ Use `nodetool` to verify that Cassandra is running (you may need to run this multiple times):
+
 ```bash
 nodetool status
 ```
 
 ✅ Start the command line tool `cqlsh`:
+
 ```bash
 cqlsh
 ```
@@ -64,6 +66,7 @@ WITH replication = {
 ```bash
 use killrvideo;
 ```
+
 </details>
 
 ✅ Create a table called `videos` with columns `video_id` of type `TIMEUUID`, `added_date` of type `TIMESTAMP` and `title` of type `TEXT`. Designate `video_id` as the primary key.
@@ -79,6 +82,7 @@ CREATE TABLE videos (
   PRIMARY KEY (video_id)
 );
 ```
+
 </details>
 
 <!-- NAVIGATION -->

--- a/step2.md
+++ b/step2.md
@@ -25,19 +25,9 @@
 
 ✅ Manually insert a single row into the table using an `INSERT` statement.
 
-<table class="katapod-table">
-  <tr>
-    <th class="katapod-table">video_id</th>
-    <th class="katapod-table">added_date</th>
-    <th class="katapod-table">title</th>
-  </tr>
-  <tr>
-    <td class="katapod-table">36b8bac0-6260-11ea-ac4c-87a8af4b7ed0</td>
-    <td class="katapod-table">2020-03-09</td>
-    <td class="katapod-table">Foundations of DataStax Enterprise</td>
-  <tr>  
-  
-</table>
+|`video_id`                 | `added_date` | `title` |
+|---------------------------|--------------|---------|
+| `36b8bac0-6260-11ea-ac4c-87a8af4b7ed0` | 2020-03-09 | Foundations of DataStax Enterprise |
 
 <details class="katapod-details">
   <summary>Solution</summary>
@@ -65,19 +55,9 @@ SELECT * from videos;
 
 ✅ Insert another row into the table.
 
-<table class="katapod-table">
-  <tr>
-    <th class="katapod-table">video_id</th>
-    <th class="katapod-table">added_date</th>
-    <th class="katapod-table">title</th>
-  </tr>
-  <tr>
-    <td class="katapod-table">95fe9800-2c2f-11b2-8080-808080808080</td>
-    <td class="katapod-table">2020-01-20</td>
-    <td class="katapod-table">Cassandra Data Modeling</td>
-  <tr>  
-  
-</table>
+|`video_id`                 | `added_date` | `title` |
+|---------------------------|--------------|---------|
+| `95fe9800-2c2f-11b2-8080-808080808080` | 2020-01-20 | Cassandra Data Modeling |
 
 <details class="katapod-details">
   <summary>Solution</summary>

--- a/step2.md
+++ b/step2.md
@@ -38,7 +38,6 @@ VALUES (36b8bac0-6260-11ea-ac4c-87a8af4b7ed0, '2020-03-09', 'Foundations of Data
 ```
 
 </details>
-<br>
 
 ✅ Use a `SELECT` statement to retrieve your row from the table.
 
@@ -50,7 +49,6 @@ SELECT * from videos;
 ```
 
 </details>
-<br>
 
 
 ✅ Insert another row into the table.
@@ -70,7 +68,6 @@ VALUES (95fe9800-2c2f-11b2-8080-808080808080, '2020-01-20', 'Cassandra Data Mode
 ```
 
 </details>
-<br>
 
 
 ✅ Retrieve all rows from the table.
@@ -89,7 +86,6 @@ SELECT * from videos;
 ```
 
 </details>
-<br>
 
 ✅ Use the `COPY` command to import data into your `videos` table.
 ```

--- a/step2.md
+++ b/step2.md
@@ -87,6 +87,7 @@ SELECT * from videos;
 </details>
 
 ✅ Use the `COPY` command to import data into your `videos` table.
+
 ```cql
 COPY videos(video_id, added_date, title)
 FROM '/workspace/ds201-lab02/data-files/videos.csv'
@@ -94,6 +95,7 @@ WITH HEADER=TRUE;
 ```
 
 ✅ Retrieve all rows from the table to verify that the table loaded correctly.
+
 ```cql
 SELECT * from videos;
 ```

--- a/step2.md
+++ b/step2.md
@@ -32,7 +32,7 @@
 <details class="katapod-details">
   <summary>Solution</summary>
 
-```
+```cql
 INSERT INTO videos (video_id, added_date, title)
 VALUES (36b8bac0-6260-11ea-ac4c-87a8af4b7ed0, '2020-03-09', 'Foundations of DataStax Enterprise');
 ```
@@ -44,7 +44,7 @@ VALUES (36b8bac0-6260-11ea-ac4c-87a8af4b7ed0, '2020-03-09', 'Foundations of Data
 <details class="katapod-details">
   <summary>Solution</summary>
 
-```
+```cql
 SELECT * from videos;
 ```
 
@@ -61,17 +61,16 @@ SELECT * from videos;
   <summary>Solution</summary>
 
 
-```
+```cql
 INSERT INTO videos (video_id, added_date, title) 
 VALUES (95fe9800-2c2f-11b2-8080-808080808080, '2020-01-20', 'Cassandra Data Modeling');
-
 ```
 
 </details>
 
 
 ✅ Retrieve all rows from the table.
-```
+```cql
 SELECT * from videos;
 ```
 
@@ -80,7 +79,7 @@ SELECT * from videos;
 <details class="katapod-details">
   <summary>Solution</summary>
 
-```
+```cql
 TRUNCATE videos;
 SELECT * from videos;
 ```
@@ -88,14 +87,14 @@ SELECT * from videos;
 </details>
 
 ✅ Use the `COPY` command to import data into your `videos` table.
-```
+```cql
 COPY videos(video_id, added_date, title)
 FROM '/workspace/ds201-lab02/data-files/videos.csv'
 WITH HEADER=TRUE;
 ```
 
 ✅ Retrieve all rows from the table to verify that the table loaded correctly.
-```
+```cql
 SELECT * from videos;
 ```
 


### PR DESCRIPTION
This uses the latest stable katapod engine (as set in .gitpod.yml). Together with some changes in the step markdown files, you get:

- syntax highlighting including the "cql" specifier (which for now translates to sql syntax, but who knows in the future)
- table styling
- collapse-block styling
- (hence no need for manual `<br>`'s anymore

Also a fix to the navigation button (which was pointing to a nonexistent step3)

Cheers!
