### PR TITLE
[fix] update cassandra tarball URL to 4.1.3

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,13 +3,13 @@ tasks:
   - name: install-dependencies
     before: |
       printf 'unset JAVA_TOOL_OPTIONS\n' >> $HOME/.bashrc
-      printf 'export PATH="/workspace/ds201-lab02/apache-cassandra-4.1.0/bin:$PATH"' >> $HOME/.bashrc
+      printf 'export PATH="/workspace/ds201-lab02/apache-cassandra-4.1.3/bin:$PATH"' >> $HOME/.bashrc
     init: |
-      curl https://dlcdn.apache.org/cassandra/4.1.0/apache-cassandra-4.1.0-bin.tar.gz \
-        --output apache-cassandra-4.1.0-bin.tar.gz
-      tar xf apache-cassandra-4.1.0-bin.tar.gz
+      curl https://dlcdn.apache.org/cassandra/4.1.3/apache-cassandra-4.1.3-bin.tar.gz \
+        --output apache-cassandra-4.1.3-bin.tar.gz
+      tar xf apache-cassandra-4.1.3-bin.tar.gz
     command: | 
-      /workspace/ds201-lab02/apache-cassandra-4.1.0/bin/cassandra
+      /workspace/ds201-lab02/apache-cassandra-4.1.3/bin/cassandra
 github:
   prebuilds:
     main: true


### PR DESCRIPTION
- 4.1.0 tarball didn't exist anymore and 404'd